### PR TITLE
Serve iPXE script instead of JSON response if system is not registered

### DIFF
--- a/server/system_handlers.go
+++ b/server/system_handlers.go
@@ -231,7 +231,7 @@ func (s *Server) getPxeConfig(w http.ResponseWriter, r *http.Request) error {
 	sys, err := s.systemRepo.GetSystemByMacAddress(mac)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
-			return NewHTTPError(err, http.StatusNotFound)
+			return response.PlainText(w, http.StatusNotFound, system.RenderNotFound())
 		}
 		return NewHTTPError(err, http.StatusInternalServerError)
 	}

--- a/system/pxe_config.go
+++ b/system/pxe_config.go
@@ -8,12 +8,22 @@ import (
 
 // TODO: create a PxeConfig interface with a Render() method, have the System struct implement it
 
+// iPXE script template that is served to clients.
+// The configured kernel, initrd and kernel parameters are substituted into it.
 var template = `#!ipxe
 
 kernel %s %s
 initrd %s
 
 boot
+`
+
+// iPXE script template that is served if the system is not registered and no profile can be found for it.
+var notFoundTemplate = `#!ipxe
+
+echo No matching profile found for system!
+prompt --timeout 30000 Press any key or wait 30 seconds to continue ||
+
 `
 
 type PxeConfig struct {
@@ -34,4 +44,8 @@ func (p PxeConfig) Render() string {
 	kp := kernelparameters.FormatKernelParameters(p.KernelParameters)
 	kpStr := strings.Join(kp, " ")
 	return fmt.Sprintf(template, p.Kernel, kpStr, p.Initrd)
+}
+
+func RenderNotFound() string {
+	return notFoundTemplate
 }


### PR DESCRIPTION
Serving a JSON response when a system expects an iPXE script will probably cause an unexpected result.
As such, this PR changes this default response to an iPXE script that does the following:
- Echoes `No matching profile found for system!` to the console of the server
- Waits for 30 seconds or user input after which it will exit out of the script/lets the server do whatever it wants.