### PR TITLE
Small Docker container-related fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,9 @@
+.git/
+.github/
+bin/
 configs/
+.dockerignore
+.gitignore
 Dockerfile
 *.md
 LICENSE

--- a/configs/docker-compose.yml
+++ b/configs/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3"
 
 services:
   gobble:
+    container_name: gobble
     image: ghcr.io/evanebb/gobble:0.0.6
     build:
       context: ../
@@ -17,6 +18,7 @@ services:
       GOBBLE_DB_NAME: gobble
 
   database:
+    container_name: gobble_database
     image: postgres:15
     volumes:
       - "db_data:/var/lib/postgresql/data"

--- a/configs/docker-compose.yml
+++ b/configs/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: ../
       dockerfile: Dockerfile
+    depends_on:
+      - database
     ports:
       - "80:80/tcp"
     environment:

--- a/configs/docker-compose.yml
+++ b/configs/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   gobble:
-    image: ghcr.io/evanebb/gobble:0.0.2
+    image: ghcr.io/evanebb/gobble:0.0.6
     build:
       context: ../
       dockerfile: Dockerfile

--- a/server/config.go
+++ b/server/config.go
@@ -53,7 +53,7 @@ func NewAppConfig() (AppConfig, error) {
 	flag.StringVar(&a.dbUser, "db-user", a.dbUser, "the database user")
 	flag.StringVar(&a.dbPass, "db-pass", a.dbPass, "the database password")
 	flag.StringVar(&a.dbHost, "db-host", a.dbHost, "the database host")
-	flag.StringVar(&a.dbName, "db-name", a.dbHost, "the database to use")
+	flag.StringVar(&a.dbName, "db-name", a.dbName, "the database to use")
 	flag.IntVar(&a.dbPort, "db-port", a.dbPort, "the database port to connect to")
 	flag.StringVar(&a.httpsCertFile, "https-cert-file", a.httpsCertFile, "the TLS certificate file to use for HTTPS")
 	flag.StringVar(&a.httpsKeyFile, "https-key-file", a.httpsKeyFile, "the TLS certificate key file to use for HTTPS")

--- a/server/server.go
+++ b/server/server.go
@@ -78,7 +78,7 @@ func NewServer() (Server, error) {
 }
 
 func (s *Server) Run() {
-	log.Println("starting API...")
+	log.Printf("starting API on %s", s.config.listenAddress)
 	s.routes()
 	if s.config.httpsEnabled {
 		log.Fatal(http.ListenAndServeTLS(s.config.listenAddress, s.config.httpsCertFile, s.config.httpsKeyFile, s.router))

--- a/server/server.go
+++ b/server/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"log"
 	"net/http"
+	"time"
 )
 
 type Server struct {
@@ -36,8 +37,20 @@ func NewServer() (Server, error) {
 		return s, err
 	}
 
-	if err = db.Ping(context.Background()); err != nil {
-		return s, err
+	start := time.Now()
+	timeout := 30 * time.Second
+
+	log.Printf("waiting %s for database...", timeout.String())
+
+	for {
+		err = db.Ping(context.Background())
+		if err == nil {
+			break
+		}
+
+		if time.Since(start) > timeout {
+			return s, err
+		}
 	}
 
 	ar, err := postgres.NewApiUserRepository(db)


### PR DESCRIPTION
- Add more `.dockerignore` entries to shrink the build context; previously it would send anything in the `bin/` folder too, which can be large.
- Fix the database name configuration directive being overwritten by the database host value when environment variables are used instead of command-line flags. Oops.
- Add a 30 second time-out to the database connection check that continuously checks whether the database is reachable instead of just immediately exiting if the initial check fails.
- Print the configured listening address in the logs when starting the API.
- In the Docker Compose file, bump the image tag to the latest release, make the Gobble container dependent on the database container and add some friendlier container names.